### PR TITLE
Added latex to docker to allow export to PDF.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM quay.io/informaticslab/asn-sharppy
 
+# Install latex tools to allow export to PDF
+RUN apt-get update -q
+RUN apt-get -qy install texlive-latex-extra texlive-fonts-recommended
+RUN apt-get -qy clean
+
 # NB Extensions
-RUN conda install -y -c conda-forge jupyter_contrib_nbextensions jupyter_dashboards
-RUN jupyter contrib nbextension install --system
-RUN conda install -y -c conda-forge nbpresent
-RUN conda install -y -c anaconda-nb-extensions nbbrowserpdf
+RUN conda install -y -c conda-forge jupyter_contrib_nbextensions jupyter_dashboards nbpresent
 
 # Add custom Jade logo / JS
 RUN mkdir -p /root/.jupyter/custom/


### PR DESCRIPTION
Remove nbbrowserpdf as couldn't get this to work.

@niallrobinson This makes the docker image a fair but bigger but at least the pdf option does work. I'd be inclined either to include this or drop PDF functionality.  I don't like it there but broken.

Thoughts?