### PR TITLE
Remove pdf print

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/informaticslab/asn-sharppy
 
 # Install latex tools to allow export to PDF
-RUN apt-get update -q
+RUN apt-get update -qy --fix-missing
 RUN apt-get -qy install texlive-latex-extra texlive-fonts-recommended
 RUN apt-get -qy clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM quay.io/informaticslab/asn-sharppy
 
-# Install latex tools to allow export to PDF
-RUN apt-get update -qy --fix-missing
-RUN apt-get -qy install texlive-latex-extra texlive-fonts-recommended
-RUN apt-get -qy clean
-
 # NB Extensions
 RUN conda install -y -c conda-forge jupyter_contrib_nbextensions jupyter_dashboards nbpresent
 

--- a/custom/custom.js
+++ b/custom/custom.js
@@ -1,1 +1,2 @@
 document.querySelector('#ipython_notebook img').alt = "JADE"
+document.getElementById('download_pdf').style.display = "none"


### PR DESCRIPTION
Even with Pandoc and Latex and and and install the PDF export still falls over on things like embedded url images, probably youtube videos etc. Just removing the option and forcing PDF via HTML the print to PDF in the browser seems to have the best results.